### PR TITLE
chore: Update application version to 1.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ sonar {
 }
 
 group = "dev.wo"
-version = "1.2.0"
+version = "1.3.0"
 
 application {
     mainClass.set("io.ktor.server.netty.EngineMain")


### PR DESCRIPTION
This PR updates the application version in `build.gradle.kts` to `1.3.0` based on a new release or manual trigger.